### PR TITLE
Refactor/config driven scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 csv_files/
 
 .DS_Store
+
+/venv
+agents.txt

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,20 @@
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License
+
+Copyright (c) 2024 - present, yumeangelica
+
+This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/4.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+You are free to:
+- Share — copy and redistribute the material in any medium or format
+- Adapt — remix, transform, and build upon the material
+
+Under the following terms:
+- Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+- NonCommercial — You may not use the material for commercial purposes.
+- ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+
+No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+
+Notices:
+You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation.
+No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.

--- a/README.md
+++ b/README.md
@@ -1,80 +1,96 @@
 # Job Finder
 
 ## Overview
-This is a Python-based application designed to automate the process of finding job listings. It efficiently gathers job data, organizes it, and saves it for easy access. Currently, the application works in Finland, but it can be easily modified to work in other countries.
+
+A Python application that scrapes job listings from [Duunitori](https://duunitori.fi), organizes the data, and saves results as CSV files. Currently targets the Finnish job market but can be adapted for other sites by modifying the config files.
 
 ## Features
-- Automated finding of job listings with specified criteria
-- Efficient data organization
-- Save results in CSV format for easy access
+
+- Config-driven scraping — selectors, parameters, and settings live in JSON files, not in code
+- Fallback selectors — if the site changes its HTML structure, the scraper tries alternative selectors automatically
+- Page validation — detects captchas, cookie walls, and structural changes instead of silently failing
+- Automatic retry with backoff on 429/5xx responses
+- Rotating user agents from a plain text file
+- Results saved as timestamped CSV files
+
+## Project Structure
+
+```
+job_finder/
+├── main.py                          # Entry point
+├── requirements.txt
+├── config/
+│   ├── agents.txt                   # User agent strings (one per line)
+│   ├── job_program_config.json      # Scraper selectors, URLs, request settings
+│   └── main_program_config.json     # Output settings, filename template, defaults
+└── src/
+    ├── __init__.py
+    ├── main_program.py              # CLI input loop
+    ├── job_program.py               # Scraper logic
+    ├── file_program.py              # CSV read/write
+    └── agent_program.py             # User agent rotation
+```
 
 ## Prerequisites
-- Python 3.12.0
-- pip 23.2.1
+
+- Python 3.12+
+- pip
 
 ## Installation
 
-### Python and pip
-Ensure you have the correct versions of Python and pip installed. You can download Python [here](https://www.python.org/downloads/) which includes pip.
-
-To check your Python version:
+1. Clone the repository:
 ```bash
-python3 --version
+git clone <repository-url>
+cd job_finder
 ```
 
-
-To check your pip version:
+2. Create a virtual environment and activate it:
 ```bash
-pip3 --version
+python3 -m venv venv
+source venv/bin/activate
 ```
 
-### Installing dependencies
-1. Navigate to the project directory
-2. Run the following command:
+3. Install dependencies:
 ```bash
-pip3 install -r requirements.txt
+pip install -r requirements.txt
 ```
 
+## Configuration
 
-## Setting up the project
-1. Clone the repository
-2. Navigate to the project directory
-3. Setup your .env file to root directory of the project (.env file should include USER_AGENTS in the following format)
--> If you don't have user agents, go to Google on your own device and type 'my user agent'. To acquire more agents, repeat this process on each device you own. Each device has its own unique user agent.
+### User Agents (`config/agents.txt`)
 
+The file ships with a default set of user agents. To add your own, visit a site like [whatismybrowser.com](https://www.whatismybrowser.com/) on different devices and paste the strings into the file, one per line.
 
-<pre>
-USER_AGENTS="agent1
-agent2
-agent3
-..."
-</pre>
+### Scraper Settings (`config/job_program_config.json`)
 
-##### Disclaimer: Use this information at your own risk, and ensure you understand what you are doing. As a developer, I am not responsible for any possible bans from websites or consequences that arise from the use of this application.
+Controls selectors, request timeouts, retry logic, and page validation. If Duunitori changes its HTML structure, update the selectors here — no code changes needed. Each selector has a `primary` and a list of `fallbacks` that are tried in order.
 
-## Running the application
-1. Navigate to the project directory
-2. Run the following command:
+### App Settings (`config/main_program_config.json`)
+
+Controls the output directory, filename template, default search values, and CSV headers.
+
+## Usage
+
 ```bash
 python3 main.py
 ```
 
-## Usage
-After starting the application, it will begin finding job listings based on the specified criteria and configurations. The results will be saved in the src/csv_files/ directory.
+You will be prompted for:
 
-When running the application, you will be prompted to enter the following information:
-- Search term (e.g. 'software engineer, or python etc.') If you leave this blank it will search for all jobs
-- Area (e.g. 'Pääkaupunkiseutu' or 'Helsinki' etc.) If you leave this blank it will search for all areas
-**Notice! If you leave both search term and area blank, it will search for all jobs in all areas. In January 2024 there were 1464 pages and almost 30 000 jobs available. 
-Use with caution!**
+- **Search term** — e.g. `python`, `react`, `data engineer`. Leave blank to search all jobs.
+- **Area** — e.g. `helsinki`, `pääkaupunkiseutu`. Leave blank to use the default from config.
+- **Type of work** — `1` for full-time, `2` for part-time.
 
-- Type of job (e.g. 'full_time' or 'part_time' etc.) If you leave this blank it will default to 'full_time'
+Results are saved to `src/csv_files/` with the format `2026-03-23_helsinki_full_time_python_jobs.csv`.
 
+> **Note:** Leaving both search term and area blank will scrape all available listings. This can mean thousands of pages — use with caution. The config has a `max_pages` safety cap (default: 50).
+
+## Disclaimer
+
+Use this application at your own risk. Ensure you understand the legal implications of web scraping in your jurisdiction. The developer is not responsible for any bans or consequences arising from the use of this application.
 
 ## License
 
-This project is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License
+This project is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
 
-Copyright (c) 2024 - present, [yumeangelica](https://github.com/yumeangelica)
-
-Remember to give credit if you use this project in your own work.
+Copyright (c) 2024 – present, [yumeangelica](https://github.com/yumeangelica)

--- a/config/job_program_config.json
+++ b/config/job_program_config.json
@@ -1,0 +1,88 @@
+{
+  "_config_version": "2.0",
+  "_last_verified": "2026-03-23",
+  "_notes": "When duunitori changes its HTML structure, update the selectors and last_verified date.",
+
+  "base_url": "https://duunitori.fi/tyopaikat",
+  "job_url_prefix": "https://duunitori.fi",
+
+  "query_params": {
+    "search": "haku",
+    "area": "alue",
+    "work_type": "filter_work_type",
+    "order_by": "order_by",
+    "page": "sivu"
+  },
+
+  "defaults": {
+    "order_by": "date_posted"
+  },
+
+  "headers": {
+    "Referer": "https://duunitori.fi",
+    "Accept-Language": "fi-FI,fi;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Connection": "keep-alive"
+  },
+
+  "request": {
+    "timeout": 10,
+    "sleep_seconds": 5,
+    "max_retries": 3,
+    "max_pages": 50,
+    "retry_status_codes": [429, 500, 502, 503, 504]
+  },
+
+  "parser": "html.parser",
+
+  "selectors": {
+    "job_container": {
+      "primary": { "tag": "div", "class": "job-box" },
+      "fallbacks": [
+        { "tag": "article", "class": "job-box" },
+        { "tag": "div", "attrs": { "data-job-id": true } },
+        { "tag": "div", "class": "job-card" },
+        { "tag": "div", "class": "job-listing" }
+      ]
+    },
+    "title": {
+      "primary": { "tag": "h3", "class": "job-box__title" },
+      "fallbacks": [
+        { "tag": "h2", "class": "job-box__title" },
+        { "tag": "h3", "class": "job-card__title" },
+        { "tag": "[data-test]", "attrs": { "data-test": "job-title" } }
+      ]
+    },
+    "company": {
+      "primary": { "tag": "span", "class": "job-box__job-location" },
+      "fallbacks": [
+        { "tag": "span", "class": "job-box__company" },
+        { "tag": "div", "class": "job-box__job-location" },
+        { "tag": "span", "class": "job-card__company" }
+      ]
+    },
+    "link": {
+      "primary": { "tag": "a", "class": "job-box__hover" },
+      "fallbacks": [
+        { "tag": "a", "class": "job-box__link" },
+        { "tag": "a", "class": "job-card__link" }
+      ],
+      "attr": "href"
+    },
+    "pagination": {
+      "primary": { "tag": "a", "class": "pagination__pagenum" },
+      "fallbacks": [
+        { "tag": "a", "class": "pagination__page" },
+        { "tag": "li", "class": "pagination__item" }
+      ]
+    }
+  },
+
+  "validation": {
+    "expected_page_markers": ["duunitori", "työpaikat", "tyopaikat"],
+    "block_markers": ["captcha", "tarkistus", "robot", "blocked", "denied"],
+    "cookie_markers": ["eväste", "cookie", "consent"],
+    "min_page_length": 1000,
+    "min_jobs_first_page": 1
+  }
+}

--- a/config/main_program_config.json
+++ b/config/main_program_config.json
@@ -1,0 +1,20 @@
+{
+  "_config_version": "2.0",
+
+  "output_dir": "src/csv_files",
+  "agents_file": "config/agents.txt",
+
+  "filename_template": "{date}_{area}_{work_type}_{search_term}_jobs.csv",
+
+  "defaults": {
+    "area": "pääkaupunkiseutu",
+    "work_type": "full_time"
+  },
+
+  "work_types": {
+    "1": "full_time",
+    "2": "part_time"
+  },
+
+  "csv_headers": ["Title", "Company", "Link"]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-beautifulsoup4==4.12.2  # For parsing HTML and XML documents
-python-dotenv==1.0.0  # To load environment variables from a .env file
-requests==2.31.0       # For making HTTP requests
+beautifulsoup4==4.12.2  # HTML parsing
+requests==2.31.0       # HTTP requests

--- a/src/agent_program.py
+++ b/src/agent_program.py
@@ -1,19 +1,49 @@
-from dotenv import load_dotenv, find_dotenv
 import random
 import os
+import json
 
-load_dotenv(find_dotenv())
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_user_agent_list = None
 
-# Get user agents from environment variable
-user_agent_list = os.getenv('USER_AGENTS').split('\n')
+
+def _load_agents():
+    """Load user agents from file lazily (only when first needed)."""
+    global _user_agent_list
+
+    if _user_agent_list is not None:
+        return _user_agent_list
+
+    # Read the agents file path from main_program_config, fall back to default
+    config_path = os.path.join(_project_root, 'config', 'main_program_config.json')
+
+    try:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+        agents_file = config.get('agents_file', 'config/agents.txt')
+    except (FileNotFoundError, json.JSONDecodeError):
+        agents_file = 'config/agents.txt'
+
+    agents_path = os.path.join(_project_root, agents_file)
+
+    try:
+        with open(agents_path, 'r', encoding='utf-8') as f:
+            _user_agent_list = [line.strip() for line in f if line.strip()]
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            f"User agent file not found: {agents_path}\n"
+            f"Create config/agents.txt in the project root."
+        )
+
+    if not _user_agent_list:
+        raise ValueError(f"User agent file is empty: {agents_path}")
+
+    return _user_agent_list
+
 
 def user_agent_switcher():
-    """Generator function to switch between user agents"""
-    if len(user_agent_list) == 0:
-        raise Exception('No user agents found')
+    """Generator that yields a random user agent on each iteration."""
+    agents = _load_agents()
 
     while True:
-        # Return a random user agent
-        agent = random.choice(user_agent_list)
-        print(f'User agent: {agent}')
+        agent = random.choice(agents)
         yield agent

--- a/src/file_program.py
+++ b/src/file_program.py
@@ -1,26 +1,57 @@
 import csv
+import json
+import os
+
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load_config():
+    """Load main_program_config.json for CSV header settings."""
+    config_path = os.path.join(_project_root, 'config', 'main_program_config.json')
+    try:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {"csv_headers": ["Title", "Company", "Link"]}
+
 
 def writer(data: list, path_to_job_folder: str, filename: str):
+    """Write job data to a CSV file."""
+    config = _load_config()
+    filepath = os.path.join(path_to_job_folder, filename)
 
-    with open(path_to_job_folder + filename, 'w', newline='', encoding='utf-8') as file:
-        writer = csv.writer(file)
-        writer.writerow(['Title', 'Company', 'Link'])
+    try:
+        with open(filepath, 'w', newline='', encoding='utf-8') as file:
+            csv_writer = csv.writer(file)
+            csv_writer.writerow(config.get('csv_headers', ['Title', 'Company', 'Link']))
 
-        for row in data:
-            writer.writerow(row)
+            for row in data:
+                csv_writer.writerow(row)
+
+        print(f"Saved: {filepath}")
+
+    except OSError as e:
+        print(f"  Error: Failed to write file: {e}")
 
 
 def reader(path_to_job_folder: str, filename: str):
-    with open(path_to_job_folder + filename, 'r', newline='', encoding='utf-8') as file:
-        reader = csv.reader(file)
-        job_count = 0
+    """Read and print the contents of a CSV file."""
+    filepath = os.path.join(path_to_job_folder, filename)
 
-        for row in reader:
-            print(', '.join(row))
-            job_count += 1
+    try:
+        with open(filepath, 'r', newline='', encoding='utf-8') as file:
+            csv_reader = csv.reader(file)
+            job_count = 0
 
-    job_count -= 1 # Subtract the header row
+            for row in csv_reader:
+                print(', '.join(row))
+                job_count += 1
 
-    print(f'Total jobs available: {job_count}') # Print the total number of jobs
-    print()
+        job_count -= 1  # Subtract the header row
+        print(f'\nTotal jobs: {job_count}')
+        print()
 
+    except FileNotFoundError:
+        print(f"  Error: File not found: {filepath}")
+    except OSError as e:
+        print(f"  Error: Failed to read file: {e}")

--- a/src/job_program.py
+++ b/src/job_program.py
@@ -1,85 +1,263 @@
-from src.agent_program import user_agent_switcher
-from bs4 import BeautifulSoup
-import requests
+import json
+import os
 import time
+import requests
+from bs4 import BeautifulSoup
+from src.agent_program import user_agent_switcher
 
-def clean_text(text: str) -> str:
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load_config():
+    """Load job_program_config.json from the config directory."""
+    config_path = os.path.join(_project_root, 'config', 'job_program_config.json')
+    try:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            f"Config file not found: {config_path}\n"
+            f"Create config/job_program_config.json in the project root."
+        )
+
+
+def _find_elements(soup, selector_config):
+    """Find elements using primary selector first, then fallbacks.
+
+    Returns:
+        (elements, selector_label) tuple.
+    """
+    primary = selector_config['primary']
+    elements = soup.find_all(primary['tag'], class_=primary.get('class'))
+
+    if elements:
+        return elements, f"{primary['tag']}.{primary.get('class', '')}"
+
+    for fallback in selector_config.get('fallbacks', []):
+        tag = fallback['tag']
+        css_class = fallback.get('class')
+        attrs = fallback.get('attrs', {})
+
+        if css_class:
+            elements = soup.find_all(tag, class_=css_class)
+        elif attrs:
+            elements = soup.find_all(tag, attrs=attrs)
+        else:
+            elements = soup.find_all(tag)
+
+        if elements:
+            label = f"{tag}.{css_class or attrs}"
+            print(f"  info: Primary selector failed, fallback matched: {label}")
+            return elements, label
+
+    return [], None
+
+
+def _find_element(parent, selector_config):
+    """Find a single element using the primary -> fallback chain."""
+    primary = selector_config['primary']
+    elem = parent.find(primary['tag'], class_=primary.get('class'))
+
+    if elem:
+        return elem
+
+    for fallback in selector_config.get('fallbacks', []):
+        tag = fallback['tag']
+        css_class = fallback.get('class')
+        attrs = fallback.get('attrs', {})
+
+        if css_class:
+            elem = parent.find(tag, class_=css_class)
+        elif attrs:
+            elem = parent.find(tag, attrs=attrs)
+
+        if elem:
+            return elem
+
+    return None
+
+
+def _validate_page(soup, config):
+    """Check if the page is a valid search results page.
+
+    Returns:
+        'ok'           - page looks good
+        'blocked'      - captcha or bot detection
+        'cookie_wall'  - cookie consent blocking content
+        'wrong_page'   - doesn't look like duunitori search results
+        'empty_page'   - page content is too short
+    """
+    validation = config['validation']
+    page_text = soup.get_text().lower()
+
+    # Is the page too short?
+    if len(page_text) < validation['min_page_length']:
+        return 'empty_page'
+
+    # Is there a captcha or block?
+    for marker in validation['block_markers']:
+        if marker in page_text and len(page_text) < 3000:
+            return 'blocked'
+
+    # Is it a cookie wall without real content?
+    for marker in validation['cookie_markers']:
+        if marker in page_text and len(page_text) < 2000:
+            return 'cookie_wall'
+
+    # Are we on the right site?
+    has_marker = any(m in page_text for m in validation['expected_page_markers'])
+    if not has_marker:
+        return 'wrong_page'
+
+    return 'ok'
+
+
+def _clean_text(text: str) -> str:
     """Remove unwanted characters from text."""
     if text:
         return text.replace('–', '').strip()
     return text
 
+
 def finder(search_term: str, area: str, type_of_work: str):
-    """Find jobs from job board"""
-    base_url = f'https://duunitori.fi/tyopaikat?haku={search_term}&alue={area}&filter_work_type={type_of_work}&order_by=date_posted'
+    """Scrape job listings from duunitori.fi.
+
+    Args:
+        search_term: keyword to search for (e.g. 'python')
+        area: location filter (e.g. 'helsinki', 'pääkaupunkiseutu')
+        type_of_work: 'full_time' or 'part_time'
+
+    Returns:
+        List of [title, company, url] lists.
+    """
+    config = _load_config()
+    selectors = config['selectors']
+    req = config['request']
+    qp = config['query_params']
+
+    # Build query parameters from config
+    params = {
+        qp['search']: search_term,
+        qp['area']: area,
+        qp['work_type']: type_of_work,
+        qp['order_by']: config['defaults']['order_by']
+    }
+
     jobs_data = []
-    time_for_sleep = 5
-    max_retries = 3
-    user_agent_generator = user_agent_switcher() # Initialize user agent generator
+    user_agent_gen = user_agent_switcher()
 
     try:
         session = requests.Session()
-        session.headers.update({ # Set headers
-            'User-Agent': next(user_agent_generator),
-            'Referer': 'https://duunitori.fi',
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Connection': 'keep-alive',
+        session.headers.update({
+            'User-Agent': next(user_agent_gen),
+            **config['headers']
         })
 
-        response = session.get(base_url, timeout=10)
+        # Fetch first page and validate page structure
+        response = session.get(
+            config['base_url'], params=params, timeout=req['timeout']
+        )
         response.raise_for_status()
-        soup = BeautifulSoup(response.text, 'html.parser') # Parse the HTML
+        soup = BeautifulSoup(response.text, config['parser'])
 
-        pagination = soup.find_all('a', class_='pagination__pagenum') # Find the pagination element
-        last_page = int(pagination[-1].text.strip()) if pagination else 1 # Get the last page number
+        # Validate the page before parsing
+        status = _validate_page(soup, config)
+        if status != 'ok':
+            print(f"  Warning: Page issue detected: {status}")
+            if status == 'blocked':
+                print("  -> Site may have detected a bot. Try again later.")
+            elif status == 'cookie_wall':
+                print("  -> Cookie wall is blocking content. Headers may need updating.")
+            elif status == 'wrong_page':
+                print("  -> Page doesn't look like duunitori search results.")
+            elif status == 'empty_page':
+                print("  -> Page has insufficient content.")
+            return []
 
-        for page in range(1, last_page + 1): # Loop through the pages
-            page_url = f"{base_url}&sivu={page}"
+        # Determine total number of pages from pagination
+        pag_elements, _ = _find_elements(soup, selectors['pagination'])
+        last_page = int(pag_elements[-1].text.strip()) if pag_elements else 1
+        last_page = min(last_page, req['max_pages'])  # Safety cap
+
+        print(f"Found {last_page} page(s) of results.")
+
+        for page in range(1, last_page + 1):
             retries = 0
 
-            while retries < max_retries:
+            while retries < req['max_retries']:
                 try:
-                    session.headers.update({'User-Agent': next(user_agent_generator)}) # Update the user agent for each request
-                    response = session.get(page_url, timeout=10)
-                    response.raise_for_status()
+                    session.headers.update({'User-Agent': next(user_agent_gen)})
+                    page_params = {**params, qp['page']: page}
 
-                    soup = BeautifulSoup(response.text, 'html.parser') # Parse the HTML
-                    jobs = soup.find_all('div', class_='job-box') # Find the job boxes on the page
+                    response = session.get(
+                        config['base_url'],
+                        params=page_params,
+                        timeout=req['timeout']
+                    )
+
+                    # Retry on specific status codes with backoff
+                    if response.status_code in req['retry_status_codes']:
+                        retries += 1
+                        wait = req['sleep_seconds'] * retries
+                        print(f"  Status {response.status_code}, waiting {wait}s... ({retries}/{req['max_retries']})")
+                        time.sleep(wait)
+                        continue
+
+                    response.raise_for_status()
+                    soup = BeautifulSoup(response.text, config['parser'])
+
+                    # Find job elements using the fallback chain
+                    jobs, used_selector = _find_elements(soup, selectors['job_container'])
 
                     if not jobs:
-                        print(f"No jobs found on page {page}. Ending search.")
+                        print(f"  No listings found on page {page}. Ending search.")
                         return jobs_data
 
-                    for job in jobs: # Loop through the job boxes
+                    # Parse individual job listings
+                    page_count = 0
+                    for job in jobs:
                         try:
-                            link_elem = job.find('a', class_='job-box__hover')
-                            title_elem = job.find('h3', class_='job-box__title')
-                            company_elem = job.find('span', class_='job-box__job-location')
+                            title_elem = _find_element(job, selectors['title'])
+                            company_elem = _find_element(job, selectors['company'])
+                            link_elem = _find_element(job, selectors['link'])
 
-                            title = clean_text(title_elem.text) if title_elem else None
-                            company = clean_text(company_elem.text) if company_elem else None
-                            url = f"https://duunitori.fi{link_elem['href']}" if link_elem and 'href' in link_elem.attrs else None
+                            title = _clean_text(title_elem.text) if title_elem else None
+                            company = _clean_text(company_elem.text) if company_elem else None
 
-                            if title and company and url:
-                                jobs_data.append([title, company, url])
+                            link_attr = selectors['link'].get('attr', 'href')
+                            url = None
+                            if link_elem and link_attr in link_elem.attrs:
+                                href = link_elem[link_attr]
+                                if href.startswith('http'):
+                                    url = href
+                                else:
+                                    url = f"{config['job_url_prefix']}{href}"
+
+                            if title and url:
+                                jobs_data.append([title, company or 'Unknown', url])
+                                page_count += 1
 
                         except Exception as e:
-                            print(f"Error extracting job data: {e}")
+                            print(f"  Warning: Failed to parse a listing: {e}")
                             continue
 
-                    print(f"Page {page} processed successfully.")
+                    print(f"  Page {page}/{last_page} — {page_count} listings")
                     break
 
                 except requests.exceptions.RequestException as e:
-                    print(f"Error on page {page}: {e}")
                     retries += 1
-                    if retries == max_retries:
-                        print(f"Max retries reached for page {page}. Skipping.")
+                    print(f"  Error on page {page} ({retries}/{req['max_retries']}): {e}")
+                    if retries >= req['max_retries']:
+                        print(f"  -> Skipping page {page}.")
 
-            time.sleep(time_for_sleep)
+            time.sleep(req['sleep_seconds'])
 
-        return jobs_data # Return the list of jobs
+        print(f"\nTotal: {len(jobs_data)} job listings found.")
+        return jobs_data
 
+    except requests.exceptions.RequestException as e:
+        print(f"  Error: Network failure on first page: {e}")
+        return []
     except Exception as e:
-        print(f"An unexpected error occurred: {e}")
+        print(f"  Error: Unexpected failure: {e}")
         return []

--- a/src/main_program.py
+++ b/src/main_program.py
@@ -1,13 +1,65 @@
+import json
+import os
+from datetime import date
 from src.job_program import finder
 from src.file_program import writer, reader
-import os
 
-# Check if the directory exists, if not create it
-def job_directory_checker(path: str):
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load_config():
+    """Load main_program_config.json with fallback defaults."""
+    config_path = os.path.join(_project_root, 'config', 'main_program_config.json')
+    try:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"  Warning: Config file missing or invalid: {e}")
+        print("  Using default settings.")
+        return {
+            "output_dir": "src/csv_files",
+            "defaults": {"area": "pääkaupunkiseutu", "work_type": "full_time"},
+            "work_types": {"1": "full_time", "2": "part_time"},
+            "filename_template": "{date}_{area}_{work_type}_{search_term}_jobs.csv"
+        }
+
+
+def _ensure_directory(path: str):
+    """Create directory if it doesn't exist."""
     if not os.path.exists(path):
         os.makedirs(path)
 
+
+def _build_filename(config, area, work_type, search_term):
+    """Build the output filename from the config template."""
+    template = config.get(
+        'filename_template',
+        '{date}_{area}_{work_type}_{search_term}_jobs.csv'
+    )
+    today = date.today().isoformat()
+
+    # Sanitize search term for use in filename
+    safe_term = search_term.replace(' ', '_').replace('/', '_') if search_term else ''
+
+    filename = template.format(
+        date=today,
+        area=area,
+        work_type=work_type,
+        search_term=safe_term
+    )
+
+    # Remove double underscores
+    while '__' in filename:
+        filename = filename.replace('__', '_')
+
+    return filename
+
+
 def run():
+    """Main entry point for the job finder application."""
+    config = _load_config()
+    defaults = config.get('defaults', {})
+    work_types = config.get('work_types', {"1": "full_time", "2": "part_time"})
 
     print()
     print('Job Finder')
@@ -15,55 +67,47 @@ def run():
 
     run_again = True
 
-
     while run_again:
 
-        # Search_term to search for
-        search_term = input('Enter a search term (for example python): ')
+        # Search term
+        search_term = input('Enter a search term (e.g. python): ').strip()
 
-        # Area to search for, currently only pääkaupunkiseutu
-        area = input('Enter an area (for example pääkaupunkiseutu or helsinki): ')
+        # Area with default
+        default_area = defaults.get('area', 'pääkaupunkiseutu')
+        area_input = input(f'Enter an area (default: {default_area}): ').strip()
+        area = area_input if area_input else default_area
 
-        # Full_time or part_time
+        # Work type from config mapping
+        type_prompt = ', '.join(f'{k} = {v}' for k, v in work_types.items())
         try:
-            type_of_work_choice = int(input('Enter type of work (1 = full_time, 2 = part_time): '))
+            choice = input(f'Enter type of work ({type_prompt}): ').strip()
+            type_of_work = work_types.get(choice)
+            if not type_of_work:
+                default_wt = defaults.get('work_type', 'full_time')
+                print(f'Invalid choice, using default: {default_wt}')
+                type_of_work = default_wt
+        except (ValueError, EOFError):
+            type_of_work = defaults.get('work_type', 'full_time')
+            print(f'Using default: {type_of_work}')
 
-            match type_of_work_choice:
-                case 1:
-                    type_of_work = 'full_time'
-                case 2:
-                    type_of_work = 'part_time'
-                case _:
-                    print('Invalid choice, defaulting to full_time')
-                    type_of_work = 'full_time'
+        # Prepare output directory and filename
+        output_dir = config.get('output_dir', 'src/csv_files')
+        _ensure_directory(output_dir)
+        filename = _build_filename(config, area, type_of_work, search_term)
 
-        except ValueError:
-            print('Invalid choice, defaulting to full_time')
-            print()
-            type_of_work = 'full_time'
-
-        # Create the path and filename
-        path_to_job_folder = 'src/csv_files/'
-
-        filename = f'{area}_{type_of_work}_{search_term}{'_' if search_term else ''}jobs.csv'
-
-        job_directory_checker(path_to_job_folder)
-
-        # Run the job finder function and save the data to a CSV file
+        # Run the scraper
+        print(f'\nSearching: "{search_term}" / {area} / {type_of_work}...\n')
         found_jobs = finder(search_term, area, type_of_work)
 
-        if found_jobs is None or len(found_jobs) == 0:
-            print('No jobs found\n')
+        if not found_jobs:
+            print('No jobs found.\n')
         else:
-            writer(found_jobs, path_to_job_folder, filename)
-            reader(path_to_job_folder, filename)
+            writer(found_jobs, output_dir, filename)
+            reader(output_dir, filename)
 
-        # Ask the user if they want to search again
-        answer = input('Search again? (y/n): ')
-
-        if answer.lower() == 'n':
+        # Ask to search again
+        answer = input('Search again? (y/n): ').strip().lower()
+        if answer in ('n', 'no'):
             run_again = False
 
-
-    print('Exiting...')
-    print()
+    print('Exiting...\n')


### PR DESCRIPTION
## Config-driven scraper with fallback selectors

### Problem

All CSS selectors and settings were hardcoded in `job_program.py`. The config files (`job_program_config.json`, `main_program_config.json`) existed but were never read. If Duunitori changed its HTML structure, the code had to be edited. There was also no way to tell whether a scrape failed due to a selector change, a captcha, or an empty result set.

### Changes

**Config (`config/`)**
- `job_program_config.json` — each selector now has a `primary` and `fallbacks` list, tried in order. Added `validation` block (captcha/cookie wall/empty page detection), `request` block (retry codes, backoff, `max_pages` safety cap), and grouped query params under `query_params`.
- `main_program_config.json` — added `filename_template`, `work_types` mapping, `csv_headers`, and `agents_file` path.

**Code (`src/`)**
- `agent_program.py` — reads agents from `config/agents.txt` lazily instead of `os.getenv()`. Removed `python-dotenv` dependency.
- `job_program.py` — all selectors and settings come from config. `_find_elements()` / `_find_element()` implement the primary → fallback chain. `_validate_page()` detects captchas, cookie walls, wrong pages, and empty responses. Retries on 429/5xx with linear backoff.
- `file_program.py` — reads CSV headers from config, proper error handling.
- `main_program.py` — reads defaults and work types from config, date in filename via template, sanitized filenames.

**Docs**
- `requirements.txt` — removed `python-dotenv`.
- `README.md` — rewritten to reflect the new architecture.

### How to test
```bash
python3 main.py
# search: python / area: helsinki / type: 1
# verify CSV is saved as 2026-03-23_helsinki_full_time_python_jobs.csv
```

To test fallback behavior: temporarily rename the primary `job-box` class in config to something wrong — the scraper should pick up a fallback or report a clear diagnostic.

### Breaking changes

- `.env` file with `USER_AGENTS` is no longer used. Agents must be in `config/agents.txt`.